### PR TITLE
Switch runtime to 5.15-21.08

### DIFF
--- a/org.pegasus_frontend.Pegasus.yml
+++ b/org.pegasus_frontend.Pegasus.yml
@@ -1,6 +1,6 @@
 app-id: org.pegasus_frontend.Pegasus
 runtime: org.kde.Platform
-runtime-version: '5.15'
+runtime-version: '5.15-21.08'
 sdk: org.kde.Sdk
 command: pegasus-fe
 finish-args:


### PR DESCRIPTION
This is just the 5.15 runtime except based on FD.O 21.08 instead of 20.08. It's a necessary maintenance update. I didn't notice anything breaking when building or running it.