### PR TITLE
Use `fallback-x11` permission instead of `x11`

### DIFF
--- a/org.pegasus_frontend.Pegasus.yml
+++ b/org.pegasus_frontend.Pegasus.yml
@@ -11,7 +11,7 @@ finish-args:
   - --share=network
   - --socket=pulseaudio
   - --socket=wayland
-  - --socket=x11
+  - --socket=fallback-x11
   - --talk-name=org.freedesktop.Flatpak
 
 modules:


### PR DESCRIPTION
Reference: https://docs.flatpak.org/en/latest/sandbox-permissions.html?highlight=fallback-x11#standard-permissions