### PR TITLE
Fix f-e-d-c typo

### DIFF
--- a/org.pegasus_frontend.Pegasus.yml
+++ b/org.pegasus_frontend.Pegasus.yml
@@ -33,9 +33,9 @@ modules:
     sources:
       - type: git
         url: https://github.com/mmatyas/pegasus-frontend.git
-        commit: 7fcdafa7585607b33690dce873ba12e06d35a112
+        commit: 996720eb9caf1edc0a33dcbd0da4e3aa56729bed
         branch: master
 
 # The below comment makes flathub-external-data-checker run,
 # see the related grep command at https://github.com/flathub/actions/blob/master/flathub-external-data-checker/entrypoint.sh
-# x-data-checker
+# x-checker-data


### PR DESCRIPTION
Fixes a typo of mine, induced by the Flatpak External Data Checker name and https://github.com/flathub/flathub/issues/1582#issuecomment-826660626. This explains why it hasn't run yet.