### PR TITLE
Update runtime to 5.15-22.08

### DIFF
--- a/org.pegasus_frontend.Pegasus.yml
+++ b/org.pegasus_frontend.Pegasus.yml
@@ -1,6 +1,6 @@
 app-id: org.pegasus_frontend.Pegasus
 runtime: org.kde.Platform
-runtime-version: 5.15-21.08
+runtime-version: 5.15-22.08
 sdk: org.kde.Sdk
 command: pegasus-fe
 finish-args:


### PR DESCRIPTION
Update the KDE runtime to 5.15-22.08.
I've noticed that using the `6.3` runtime (Qt 6.3) produced errors, which are relatively minor but will require to add macros for backward compatibility. For instance `QRegExp` in Qt5 which has to be changed to `QRegularExpression` in Qt6.

In any case you want to reproduce the build error:
```
flatpak install org.kde.Platform/x86_64/6.3 org.kde.Sdk/x86_64/6.3
sed -i 's/5.15-22.08/6.3/' org.pegasus_frontend.Pegasus.yml
flatpak run org.flatpak.Builder --install --user --force-clean build-dir org.pegasus_frontend.Pegasus.yml
```